### PR TITLE
refactor: remove dead code

### DIFF
--- a/pkg/cli/app_test.go
+++ b/pkg/cli/app_test.go
@@ -2,14 +2,15 @@ package cli
 
 import (
 	"context"
+	"errors"
+	"testing"
+
 	"ecs-task-def-action/pkg/decoder"
 	"ecs-task-def-action/pkg/encoder"
 	"ecs-task-def-action/pkg/git"
 	"ecs-task-def-action/pkg/github"
 	"ecs-task-def-action/pkg/plovider/ecs"
 	"ecs-task-def-action/pkg/transformer"
-	"errors"
-	"testing"
 
 	mock_decoder "ecs-task-def-action/mock/decoder"
 	mock_encoder "ecs-task-def-action/mock/encoder"
@@ -392,7 +393,4 @@ func Test_execute(t *testing.T) {
 			assert.Equal(t, test.expected, result)
 		})
 	}
-}
-
-func Test_executte_Container_Definition(t *testing.T) {
 }

--- a/pkg/cli/app_test.go
+++ b/pkg/cli/app_test.go
@@ -2,15 +2,14 @@ package cli
 
 import (
 	"context"
-	"errors"
-	"testing"
-
 	"ecs-task-def-action/pkg/decoder"
 	"ecs-task-def-action/pkg/encoder"
 	"ecs-task-def-action/pkg/git"
 	"ecs-task-def-action/pkg/github"
 	"ecs-task-def-action/pkg/plovider/ecs"
 	"ecs-task-def-action/pkg/transformer"
+	"errors"
+	"testing"
 
 	mock_decoder "ecs-task-def-action/mock/decoder"
 	mock_encoder "ecs-task-def-action/mock/encoder"


### PR DESCRIPTION
remove test code because cli/app execute is used template method pattern